### PR TITLE
Add missing curly braces

### DIFF
--- a/mimetic/codec/other_codecs.h
+++ b/mimetic/codec/other_codecs.h
@@ -89,8 +89,9 @@ struct Lf2CrLf: public unbuffered_codec, public chainable_codec<Lf2CrLf>
         {
             *out = CR; ++out;
             *out = LF; ++out; 
-        } else
+        } else {
             *out = c; ++out;
+        }
     }
     const char* name() const
     {    


### PR DESCRIPTION
Due to lack of curly braces, ++out was actually outside the else
clause despite the indentation.
