### PR TITLE
Remove register keyword

### DIFF
--- a/mimetic/parser/itparser.h
+++ b/mimetic/parser/itparser.h
@@ -234,7 +234,7 @@ protected:
             sValue,
             sIgnoreHeader
         };
-        register int status;
+        int status;
         int pos;
         char *name, *value;
         size_t nBufSz, vBufSz, nPos, vPos;
@@ -472,7 +472,7 @@ protected:
     virtual void copy_until_boundary(ParsingElem pe)
     {
         size_t pos, lines, eomsz = 0;
-        register char c;
+        char c;
         enum { nlsz = 1 };
         const char *eom = 0;
 


### PR DESCRIPTION
It has been deprecated for some time and finally removed in C++17.